### PR TITLE
Fixes for substitutions & support variable installation dir

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,8 @@
 ### freddiaN's CPMA 1.50 Server Netinstaller script
 ## This is an automated script used for setting up servers quickly and (hopefully) without any pain points
 
+DIR=${1:-$HOME}
+
 echo "You are using freddiaN's CPMA 1.50 Server netinstaller."
 echo "This script will ask you a few questions and download everything needed to get a server up and running."
 echo ""
@@ -63,31 +65,30 @@ read -r -p "do you want to continue the installation? [y/N] " response
 
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
 then
-    # Making sure the server is located in $HOME TODO: change this to a variable path
-    cd $HOME
+    cd $DIR
 
     # Get the server files
     wget http://freddian.tf/cpma-barebones-server.zip -O cpma.zip
     unzip cpma.zip
 
     # Get the .pk3s from somewhere else because I don't wanna get fucked for hosting them myself
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak0.pk3 -O $HOME/serverfiles/baseq3/pak0.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak1.pk3 -O $HOME/serverfiles/baseq3/pak1.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak2.pk3 -O $HOME/serverfiles/baseq3/pak2.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak3.PK3 -O $HOME/serverfiles/baseq3/pak3.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak4.pk3 -O $HOME/serverfiles/baseq3/pak4.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak5.pk3 -O $HOME/serverfiles/baseq3/pak5.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak6.pk3 -O $HOME/serverfiles/baseq3/pak6.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak7.PK3 -O $HOME/serverfiles/baseq3/pak7.pk3
-    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak8.pk3 -O $HOME/serverfiles/baseq3/pak8.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak0.pk3 -O $DIR/serverfiles/baseq3/pak0.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak1.pk3 -O $DIR/serverfiles/baseq3/pak1.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak2.pk3 -O $DIR/serverfiles/baseq3/pak2.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak3.PK3 -O $DIR/serverfiles/baseq3/pak3.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak4.pk3 -O $DIR/serverfiles/baseq3/pak4.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak5.pk3 -O $DIR/serverfiles/baseq3/pak5.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak6.pk3 -O $DIR/serverfiles/baseq3/pak6.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak7.PK3 -O $DIR/serverfiles/baseq3/pak7.pk3
+    wget http://game.pioneernet.ru/dl/q3/files/pk3/pak8.pk3 -O $DIR/serverfiles/baseq3/pak8.pk3
 
     # Create start script
-    sed -i -e "s/.screenname/${screenname}/g" $HOME/start.sh
-    sed -i -e "s/.port/${port}/g" $HOME/start.sh
-    chmod +x $HOME/start.sh
+    sed -i -e "s/.screenname/${screenname}/g" $DIR/start.sh
+    sed -i -e "s/.port/${port}/g" $DIR/start.sh
+    chmod +x $DIR/start.sh
 
     # setting up q3server.cfg
-    cd $HOME/serverfiles/baseq3/
+    cd $DIR/serverfiles/baseq3/
     sed -i -e "s/.servername/${servername}/g" q3server.cfg
     sed -i -e "s/.rconpw/${rconpw}/g" q3server.cfg
     sed -i -e "s/.serverpw/${serverpw}/g" q3server.cfg

--- a/setup.sh
+++ b/setup.sh
@@ -83,34 +83,43 @@ then
     wget http://game.pioneernet.ru/dl/q3/files/pk3/pak8.pk3 -O $DIR/serverfiles/baseq3/pak8.pk3
 
     # Create start script
-    sed -i -e "s/.screenname/${screenname}/g" $DIR/start.sh
-    sed -i -e "s/.port/${port}/g" $DIR/start.sh
+    sed -i -e "s/\.screenname/${screenname}/g" $DIR/start.sh
+    sed -i -e "s/\.port/${port}/g" $DIR/start.sh
+    sed -i -e "s/\.dir/${DIR}/g" $DIR/start.sh
     chmod +x $DIR/start.sh
 
     # setting up q3server.cfg
     cd $DIR/serverfiles/baseq3/
-    sed -i -e "s/.servername/${servername}/g" q3server.cfg
-    sed -i -e "s/.rconpw/${rconpw}/g" q3server.cfg
-    sed -i -e "s/.serverpw/${serverpw}/g" q3server.cfg
-    sed -i -e "s/.refpw/${refpw}/g" q3server.cfg
-    sed -i -e "s/.cntry/${cntry}/g" q3server.cfg
-    sed -i -e "s/.stt/${stt}/g" q3server.cfg
-    sed -i -e "s/.cty/${cty}/g" q3server.cfg
-    sed -i -e "s/.un/${username}/g" q3server.cfg
-    sed -i -e "s/.id/${dc_id}/g" q3server.cfg
+    sed -i -e "s/\.servername/${servername}/g" q3server.cfg
+    sed -i -e "s/\.rconpw/${rconpw}/g" q3server.cfg
+    sed -i -e "s/\.serverpw/${serverpw}/g" q3server.cfg
+    sed -i -e "s/\.refpw/${refpw}/g" q3server.cfg
+    sed -i -e "s/\.cntry/${cntry}/g" q3server.cfg
+    sed -i -e "s/\.stt/${stt}/g" q3server.cfg
+    sed -i -e "s/\.cty/${cty}/g" q3server.cfg
+    sed -i -e "s/\.city/${cty}/g" q3server.cfg
+    sed -i -e "s/\.un/${username}/g" q3server.cfg
+    sed -i -e "s/\.id/${dc_id}/g" q3server.cfg
+
+    if [[ "$state" =~ "" ]]
+    then
+        sed -i -e "s/\.state\.country/${cntry}/g" q3server.cfg
+    else
+        sed -i -e "s/\.state\.country/${stt}/g" q3server.cfg
+    fi
 
     # setting up motd.txt
     if [[ "$state" =~ "" ]]
     then
-        sed -i -e "s/.cntry/${cntry}/g" motd.txt
-        sed -i -e "s/.cty/${cty}/g" motd.txt
+        sed -i -e "s/\.stt\.cntry/${cntry}/g" motd.txt
+        sed -i -e "s/\.cty/${cty}/g" motd.txt
     else
-        sed -i -e "s/.cntry/${stt}/g" motd.txt
-        sed -i -e "s/.cty/${cty}/g" motd.txt
+        sed -i -e "s/\.stt\.cntry/${stt}/g" motd.txt
+        sed -i -e "s/\.cty/${cty}/g" motd.txt
     fi
     
-    sed -i -e "s/.un/${username}/g" motd.txt
-    sed -i -e "s/.id/${dc_id}/g" motd.txt
+    sed -i -e "s/\.un/${username}/g" motd.txt
+    sed -i -e "s/\.id/${dc_id}/g" motd.txt
 
     # end script
 


### PR DESCRIPTION
This pull request contains two things (sorry for including that in one PR, but it was easier for me to develop and test):

* adds an options to specify installation directory by executing setup with an argument (`bash setup.sh /path/to/install`
* Fixes some substitution issues in the config files.

This requires only one change in `cpma.zip` — `start.sh` should have edited `+set fs_basepath $HOME/serverfiles` to `+set fs_basepath .dir/serverfiles`. Since the ability to install to a specified path is not documented, you do not have to do that change — the setup script will fallback to `$HOME` when run without any argument and everything should just work.